### PR TITLE
Fixed parameter name of setCurrentLanguage

### DIFF
--- a/src/main/java/eu/mihosoft/monacofx/Editor.java
+++ b/src/main/java/eu/mihosoft/monacofx/Editor.java
@@ -166,8 +166,8 @@ public final class Editor {
         return this.currentLanguageProperty;
     }
 
-    public void setCurrentLanguage(String theme) {
-        currentLanguageProperty().set(theme);
+    public void setCurrentLanguage(String language) {
+        currentLanguageProperty().set(language);
     }
 
     public String getCurrentLanguage() {


### PR DESCRIPTION
Changed the name of the parameter of the method setCurrentLanguage from "theme" to "language"